### PR TITLE
Get Debian codename from os-release

### DIFF
--- a/eo/install.md
+++ b/eo/install.md
@@ -46,12 +46,8 @@ Oni povas instali `wslu` per la jenaj komandoj:
 sudo apt install gnupg2 apt-transport-https
 wget -O - https://pkg.wslutiliti.es/public.key | sudo gpg -o /usr/share/keyrings/wslu-archive-keyring.pgp --dearmor
 
-# Debian 10
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 11
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bullseye main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 12
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bookworm main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
+echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian \
+$(. /etc/os-release && echo "$VERSION_CODENAME") main" | sudo tee /etc/apt/sources.list.d/wslu.list
 
 sudo apt update
 sudo apt install wslu

--- a/install.md
+++ b/install.md
@@ -46,13 +46,8 @@ You can install `wslu` with the following command:
 sudo apt install gnupg2 apt-transport-https
 wget -O - https://pkg.wslutiliti.es/public.key | sudo gpg -o /usr/share/keyrings/wslu-archive-keyring.pgp --dearmor
 
-# Debian 10
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 11
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bullseye main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 12
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bookworm main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-
+echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian \
+$(. /etc/os-release && echo "$VERSION_CODENAME") main" | sudo tee /etc/apt/sources.list.d/wslu.list
 
 sudo apt update
 sudo apt install wslu

--- a/zh-CN/install.md
+++ b/zh-CN/install.md
@@ -46,13 +46,8 @@ sudo yum install wslu
 sudo apt install gnupg2 apt-transport-https
 wget -O - https://pkg.wslutiliti.es/public.key | sudo gpg -o /usr/share/keyrings/wslu-archive-keyring.pgp --dearmor
 
-# Debian 10
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 11
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bullseye main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 12
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bookworm main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-
+echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian \
+$(. /etc/os-release && echo "$VERSION_CODENAME") main" | sudo tee /etc/apt/sources.list.d/wslu.list
 
 sudo apt update
 sudo apt install wslu

--- a/zh-TW/install.md
+++ b/zh-TW/install.md
@@ -46,12 +46,8 @@ sudo yum install wslu
 sudo apt install gnupg2 apt-transport-https
 wget -O - https://pkg.wslutiliti.es/public.key | sudo gpg -o /usr/share/keyrings/wslu-archive-keyring.pgp --dearmor
 
-# Debian 10
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 11
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bullseye main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
-# Debian 12
-echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian bookworm main" | sudo tee -a /etc/apt/sources.list.d/wslu.list
+echo "deb [signed-by=/usr/share/keyrings/wslu-archive-keyring.pgp] https://pkg.wslutiliti.es/debian \
+$(. /etc/os-release && echo "$VERSION_CODENAME") main" | sudo tee /etc/apt/sources.list.d/wslu.list
 
 sudo apt update
 sudo apt install wslu


### PR DESCRIPTION
There is no need to write specific command for each Debian version, they just have different codenames, which you can get from os-release.

There is also no need to append a `sources.list` file, as in most cases, only one source is needed.

---

Reference: https://docs.docker.com/engine/install/debian/#install-using-the-repository